### PR TITLE
Async only 2 for now, later improve deploy check

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "dependencies": {
     "@endeavorb2b/rancher2api": "^1.0.4",
+    "async": "^2.6.2",
     "aws-sdk": "^2.430.0",
     "node-fetch": "^2.3.0",
     "uuid": "^3.3.2",


### PR DESCRIPTION
I changed this a bit so that it breaks up all the api calls with the deployments to make them more linear. Next step would be to actually check for the deployment success instead of assuming it's good. This should help deployments quite a bit though until the 2nd part is done.